### PR TITLE
Dont retry forever

### DIFF
--- a/lib/active_resource/connection_ext.rb
+++ b/lib/active_resource/connection_ext.rb
@@ -35,6 +35,8 @@ module ActiveResource
         if tries > 0 && e.response.class.in?(Net::HTTPTooManyRequests, Net::HTTPInternalServerError)
           wait
           retry
+        else
+          raise
         end
       end
 

--- a/lib/active_resource/connection_ext.rb
+++ b/lib/active_resource/connection_ext.rb
@@ -28,13 +28,13 @@ module ActiveResource
 
     module RedoIfTemporaryError
       def request(*args)
+        tries ||= 5
         super
       rescue ActiveResource::ClientError, ActiveResource::ServerError => e
-        if e.response.class.in?(Net::HTTPTooManyRequests, Net::HTTPInternalServerError)
+        tries -= 1
+        if tries > 0 && e.response.class.in?(Net::HTTPTooManyRequests, Net::HTTPInternalServerError)
           wait
-          request *args
-        else
-          raise
+          retry
         end
       end
 


### PR DESCRIPTION
This function affects the entire of ActiveResource and not just Shopify API causing other APIs which use the 500 error to infinitely loop while retrying a request which should not have been retried.
